### PR TITLE
Convert to newer package versions

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,17 +1,3 @@
 """Initializes the flask application"""
 
-import pathlib
-import sys
-
-# configure application and packages
-import app.data_integration
-import app.bigquery_downloader
-import app.ui
-
-# apply environment specific settings (not in git repo)
-if not pathlib.Path(__file__).parent.joinpath('local_setup.py').exists():
-    sys.stderr.write('Please copy app/local_setup.py.example to app/local_setup.py and adapt\n')
-    sys.exit(-1)
-else:
-    import app.local_setup
 

--- a/app/app.py
+++ b/app/app.py
@@ -1,9 +1,21 @@
-from mara_app.app import MaraApp
+import pathlib
+import sys
+
+from mara_config import register_functionality
+
+def compose_mara_app():
+    # configure application and packages
+    import app.data_integration
+    import app.bigquery_downloader
+    import app.ui
+
+    app.data_integration.compose_data_integration()
+    app.bigquery_downloader.compose_bigquery_downloader()
+    app.ui.compose_ui()
+    register_functionality(app.ui)
 
 
-app = MaraApp()
-
-# from werkzeug.contrib.profiler import ProfilerMiddleware
-# app.wsgi_app = ProfilerMiddleware(app.wsgi_app, profile_dir='/tmp/')
-
-wsgi_app = app.wsgi_app
+# the flask app
+def create_app():
+    from mara_app.app import MaraApp
+    return MaraApp()

--- a/app/bigquery_downloader/__init__.py
+++ b/app/bigquery_downloader/__init__.py
@@ -2,27 +2,31 @@
 
 import pathlib
 
-import bigquery_downloader.config
-from mara_config.config_system import patch
+from mara_config import set_config, register_functionality
 
 import app.config
 
 
-@patch(bigquery_downloader.config.data_sets)
-def data_sets():
-    return [
-        bigquery_downloader.config.DataSet(
-            query_file_path=pathlib.Path('app/bigquery_downloader/pypi-downloads.sql'),
-            json_credentials_path='app/bigquery_downloader/bigquery-credentials.json',
-            first_date=app.config.first_date(),
-            output_file_name='pypi/downloads-v1.csv.gz',
-            use_legacy_sql=False,
-            data_dir=app.config.data_dir()),
-        bigquery_downloader.config.DataSet(
-            query_file_path=pathlib.Path('app/bigquery_downloader/github-repo-activity.sql'),
-            json_credentials_path='app/bigquery_downloader/bigquery-credentials.json',
-            first_date=app.config.first_date(),
-            output_file_name='github/repo-activity-v1.csv.gz',
-            use_legacy_sql=False,
-            data_dir=app.config.data_dir())
-    ]
+def compose_bigquery_downloader():
+    import bigquery_downloader
+    register_functionality(bigquery_downloader)
+
+    @set_config('bigquery_downloader.config.data_sets')
+    def data_sets():
+        import bigquery_downloader.config
+        return [
+            bigquery_downloader.config.DataSet(
+                query_file_path=pathlib.Path('app/bigquery_downloader/pypi-downloads.sql'),
+                json_credentials_path='app/bigquery_downloader/bigquery-credentials.json',
+                first_date=app.config.first_date(),
+                output_file_name='pypi/downloads-v1.csv.gz',
+                use_legacy_sql=False,
+                data_dir=app.config.data_dir()),
+            bigquery_downloader.config.DataSet(
+                query_file_path=pathlib.Path('app/bigquery_downloader/github-repo-activity.sql'),
+                json_credentials_path='app/bigquery_downloader/bigquery-credentials.json',
+                first_date=app.config.first_date(),
+                output_file_name='github/repo-activity-v1.csv.gz',
+                use_legacy_sql=False,
+                data_dir=app.config.data_dir())
+        ]

--- a/app/bigquery_downloader/__init__.py
+++ b/app/bigquery_downloader/__init__.py
@@ -3,7 +3,7 @@
 import pathlib
 
 import bigquery_downloader.config
-from mara_app.monkey_patch import patch
+from mara_config.config_system import patch
 
 import app.config
 

--- a/app/config.py
+++ b/app/config.py
@@ -3,11 +3,15 @@
 import pathlib
 import datetime
 
+from mara_config import declare_config
+
+@declare_config()
 def data_dir():
     """The directory where persistent input data is stored"""
     return pathlib.Path('./data')
 
 
+@declare_config()
 def first_date():
     """The first date for which downloading and integrating BigQuery data"""
     return datetime.date(2017, 1, 1)

--- a/app/data_integration/__init__.py
+++ b/app/data_integration/__init__.py
@@ -3,39 +3,41 @@
 import datetime
 import functools
 
-import data_integration.config
-import etl_tools.config
-from data_integration.pipelines import Pipeline
-from mara_config.config_system import patch
+from mara_config import set_config, register_functionality
 
 import app.config
 
-patch(data_integration.config.data_dir)(lambda: app.config.data_dir())
-patch(data_integration.config.first_date)(lambda: app.config.first_date())
-patch(data_integration.config.default_db_alias)(lambda: 'dwh')
 
+def compose_data_integration():
+    import data_integration
+    import etl_tools
+    register_functionality(data_integration)
+    register_functionality(etl_tools)
+    set_config('data_integration.config.data_dir')(lambda: app.config.data_dir())
+    set_config('data_integration.config.first_date')(lambda: app.config.first_date())
+    set_config('data_integration.config.default_db_alias')(lambda: 'dwh')
 
-@patch(data_integration.config.root_pipeline)
-@functools.lru_cache(maxsize=None)
-def root_pipeline():
-    import app.data_integration.pipelines.github
-    import app.data_integration.pipelines.pypi
-    import app.data_integration.pipelines.utils
-    import app.data_integration.pipelines.python_projects
+    @set_config('data_integration.config.root_pipeline')
+    @functools.lru_cache(maxsize=None)
+    def root_pipeline():
+        from data_integration.pipelines import Pipeline
+        import app.data_integration.pipelines.github
+        import app.data_integration.pipelines.pypi
+        import app.data_integration.pipelines.utils
+        import app.data_integration.pipelines.python_projects
 
-    pipeline = Pipeline(
-        id='mara_example_project',
-        description='An example pipeline that integrates PyPI download stats with the Github activity of a project')
+        pipeline = Pipeline(
+            id='mara_example_project',
+            description='An example pipeline that integrates PyPI download stats with the Github activity of a project')
 
-    pipeline.add(app.data_integration.pipelines.utils.pipeline)
-    pipeline.add(app.data_integration.pipelines.pypi.pipeline, upstreams=['utils'])
-    pipeline.add(app.data_integration.pipelines.github.pipeline, upstreams=['utils'])
-    pipeline.add(app.data_integration.pipelines.python_projects.pipeline,
-                 upstreams=['pypi', 'github'])
-    return pipeline
+        pipeline.add(app.data_integration.pipelines.utils.pipeline)
+        pipeline.add(app.data_integration.pipelines.pypi.pipeline, upstreams=['utils'])
+        pipeline.add(app.data_integration.pipelines.github.pipeline, upstreams=['utils'])
+        pipeline.add(app.data_integration.pipelines.python_projects.pipeline,
+                     upstreams=['pypi', 'github'])
+        return pipeline
 
-
-patch(etl_tools.config.number_of_chunks)(lambda: 11)
-patch(etl_tools.config.first_date_in_time_dimensions)(lambda: app.config.first_date())
-patch(etl_tools.config.last_date_in_time_dimensions)(
-    lambda: datetime.datetime.utcnow().date() - datetime.timedelta(days=1))
+    set_config('etl_tools.config.number_of_chunks')(lambda: 11)
+    set_config('etl_tools.config.first_date_in_time_dimensions')(lambda: app.config.first_date())
+    set_config('etl_tools.config.last_date_in_time_dimensions')(
+        lambda: datetime.datetime.utcnow().date() - datetime.timedelta(days=1))

--- a/app/data_integration/__init__.py
+++ b/app/data_integration/__init__.py
@@ -6,7 +6,7 @@ import functools
 import data_integration.config
 import etl_tools.config
 from data_integration.pipelines import Pipeline
-from mara_app.monkey_patch import patch
+from mara_config.config_system import patch
 
 import app.config
 

--- a/app/ui/__init__.py
+++ b/app/ui/__init__.py
@@ -1,17 +1,7 @@
 """Set up Navigation, ACL & Logos"""
 
-
-import data_integration
 import flask
-import mara_acl
-import mara_acl.users
-import mara_app
-import mara_app.layout
-import mara_db
-import mara_page.acl
-from mara_config.config_system import wrap, patch
-from mara_page import acl
-from mara_page import navigation
+from mara_config import set_config, register_functionality
 
 from app.ui import start_page
 
@@ -19,52 +9,66 @@ blueprint = flask.Blueprint('ui', __name__, url_prefix='/ui', static_folder='sta
 
 MARA_FLASK_BLUEPRINTS = [start_page.blueprint, blueprint]
 
-# replace logo and favicon
-patch(mara_app.config.favicon_url)(lambda: flask.url_for('ui.static', filename='favicon.ico'))
-patch(mara_app.config.logo_url)(lambda: flask.url_for('ui.static', filename='logo.png'))
 
+def compose_ui():
+    import mara_acl
+    import mara_app
+    import mara_db
+    import mara_page
+    import data_integration
+    from mara_page import acl
+    from mara_page import navigation
+    import mara_acl.users
+    import mara_acl.permissions
+    register_functionality(mara_acl)
+    register_functionality(mara_page)
+    register_functionality(mara_app)
+    register_functionality(mara_db)
+    register_functionality(data_integration)
 
-# add custom css
-@wrap(mara_app.layout.css_files)
-def css_files(original_function, response):
-    files = original_function(response)
-    files.append(flask.url_for('ui.static', filename='styles.css'))
-    return files
+    # replace logo and favicon
+    set_config('mara_app.config.favicon_url')(lambda: flask.url_for('ui.static', filename='favicon.ico'))
+    set_config('mara_app.config.logo_url')(lambda: flask.url_for('ui.static', filename='logo.png'))
 
+    # add custom css
+    @set_config('mara_app.layout.css_files', include_original_function=True)
+    def css_files(original_function, response):
+        files = original_function(response)
+        files.append(flask.url_for('ui.static', filename='styles.css'))
+        return files
 
-# define protected ACL resources
-@patch(mara_acl.config.resources)
-def acl_resources():
-    def iter(iterator_or_callable):
-        if callable(iterator_or_callable):
-            iterator_or_callable = iterator_or_callable()
-        return iterator_or_callable
-    return [acl.AclResource(name='Documentation',
-                            children=iter(data_integration.MARA_ACL_RESOURCES)
-                                     + iter(mara_db.MARA_ACL_RESOURCES)),
-            acl.AclResource(name='Admin',
-                            children=iter(mara_app.MARA_ACL_RESOURCES) + iter(mara_acl.MARA_ACL_RESOURCES))]
+    # define protected ACL resources
+    @set_config('mara_acl.config.resources')
+    def acl_resources():
+        def iter(iterator_or_callable):
+            if callable(iterator_or_callable):
+                iterator_or_callable = iterator_or_callable()
+            return iterator_or_callable
 
+        return [acl.AclResource(name='Documentation',
+                                children=iter(data_integration.MARA_ACL_RESOURCES)
+                                         + iter(mara_db.MARA_ACL_RESOURCES)),
+                acl.AclResource(name='Admin',
+                                children=iter(mara_app.MARA_ACL_RESOURCES) + iter(mara_acl.MARA_ACL_RESOURCES))]
 
-# activate ACL
-patch(mara_page.acl.current_user_email)(mara_acl.users.current_user_email)
-patch(mara_page.acl.current_user_has_permission)(mara_acl.permissions.current_user_has_permission)
-patch(mara_page.acl.current_user_has_permissions)(mara_acl.permissions.current_user_has_permissions)
+    # activate ACL
+    set_config('mara_page.acl.current_user_email')(mara_acl.users.current_user_email)
+    set_config('mara_page.acl.current_user_has_permission')(mara_acl.permissions.current_user_has_permission)
+    set_config('mara_page.acl.current_user_has_permissions')(mara_acl.permissions.current_user_has_permissions)
 
-patch(mara_acl.config.whitelisted_uris)(lambda: ['/mara-app/navigation-bar'])
+    set_config('mara_acl.config.whitelisted_uris')(lambda: ['/mara-app/navigation-bar'])
 
+    # navigation bar (other navigation entries will be automatically added)
+    @set_config('mara_app.config.navigation_root')
+    def navigation_root() -> navigation.NavigationEntry:
+        def navigation_entries(module):
+            navigation_entries = module.MARA_NAVIGATION_ENTRY_FNS
+            if callable(navigation_entries):
+                navigation_entries = navigation_entries()
 
-# navigation bar (other navigation entries will be automatically added)
-@patch(mara_app.config.navigation_root)
-def navigation_root() -> navigation.NavigationEntry:
-    def navigation_entries(module):
-        navigation_entries = module.MARA_NAVIGATION_ENTRY_FNS
-        if callable(navigation_entries):
-            navigation_entries = navigation_entries()
+            return [fn() for fn in navigation_entries]
 
-        return [fn() for fn in navigation_entries]
-
-    return navigation.NavigationEntry(label='Root', children=(
-            navigation_entries(data_integration)
-            + [navigation.NavigationEntry('Settings', icon='cog', description='ACL & Configuration', rank=100,
-                                          children=navigation_entries(mara_app) + navigation_entries(mara_acl))]))
+        return navigation.NavigationEntry(label='Root', children=(
+                navigation_entries(data_integration)
+                + [navigation.NavigationEntry('Settings', icon='cog', description='ACL & Configuration', rank=100,
+                                              children=navigation_entries(mara_app) + navigation_entries(mara_acl))]))

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,8 @@
 
 # running flask
 gunicorn
+# To get better app discovering
+flask>1.0
 
 # downloading data from s3
 awscli<1.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,8 @@
 -e git+https://github.com/mara/data-integration.git@1.0.0#egg=data-integration
 -e git+https://github.com/mara/bigquery-downloader.git@1.0.0#egg=bigquery-downloader
 -e git+https://github.com/mara/etl-tools.git@1.0.0#egg=etl-tools
--e git+https://github.com/mara/mara-config.git@0.1#egg=mara-config
+-e git+https://github.com/jankatins/mara-config.git@master#egg=mara-config
+-e git+https://github.com/jankatins/mara-cli.git@master#egg=mara-cli
 
 # running flask
 gunicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@
 -e git+https://github.com/mara/data-integration.git@1.0.0#egg=data-integration
 -e git+https://github.com/mara/bigquery-downloader.git@1.0.0#egg=bigquery-downloader
 -e git+https://github.com/mara/etl-tools.git@1.0.0#egg=etl-tools
+-e git+https://github.com/mara/mara-config.git@0.1#egg=mara-config
 
 # running flask
 gunicorn

--- a/requirements.txt.freeze
+++ b/requirements.txt.freeze
@@ -1,5 +1,6 @@
 alembic==0.9.9
 asn1crypto==0.24.0
+attrs==18.1.0
 awscli==1.13.0
 -e git+https://github.com/mara/bigquery-downloader.git@9385355eec61485eebb89992cab88877d5b9ec37#egg=bigquery_downloader
 BigQuery-Python==1.14.0
@@ -13,10 +14,10 @@ cryptography==2.2.2
 -e git+https://github.com/mara/data-integration.git@867315c33de1312100075e88f942d20080818f08#egg=data_integration
 docutils==0.14
 -e git+https://github.com/mara/etl-tools.git@1497edaf865550389d2df44bf488c4348896c6d8#egg=etl_tools
-Flask==0.12.2
+Flask==1.0.2
 google-api-python-client==1.6.6
 graphviz==0.8.2
-gunicorn==19.7.1
+gunicorn==19.8.1
 httplib2==0.11.3
 idna==2.6
 itsdangerous==0.24
@@ -25,6 +26,8 @@ jmespath==0.9.3
 Mako==1.0.7
 -e git+https://github.com/mara/mara-acl.git@9d0ef617e6c3baa2df2824935e63921fdbddfc60#egg=mara_acl
 -e git+https://github.com/mara/mara-app.git@66ba874d50fd30910ecf38f8c313c3a9f7e6624a#egg=mara_app
+-e git+https://github.com/jankatins/mara-cli.git@c1c1e7ddf940f1886c66528ffa994cec7ed5b2cd#egg=mara_cli
+-e git+https://github.com/jankatins/mara-config.git@f80cd0247dd49128422c204a1e252b43924d271d#egg=mara_config
 -e git+https://github.com/mara/mara-db.git@4b496a8f82b780753c698cee70fe5619779d3906#egg=mara_db
 -e git+https://github.com/mara/mara-page.git@b1c32141080a322c9d8a7613ae1dc070479f762d#egg=mara_page
 MarkupSafe==1.0
@@ -32,13 +35,16 @@ more-itertools==4.1.0
 multimethod==0.7.1
 oauth2client==4.1.2
 pipdeptree==0.12.1
+pluggy==0.6.0
 psutil==5.4.5
 psycopg2-binary==2.7.4
+py==1.5.3
 pyasn1==0.4.2
 pyasn1-modules==0.2.1
 pycparser==2.18
 Pygments==2.2.0
 pyOpenSSL==17.5.0
+pytest==3.5.1
 python-dateutil==2.7.2
 python-editor==1.0.3
 pythondialog==3.4.0

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,9 @@
+# Flask autodiscovery file: Flask >1.0 will automatically use the wsgi.py file in the root directory
+from app.app import create_app
+
+app = create_app()
+
+# from werkzeug.contrib.profiler import ProfilerMiddleware
+# app.wsgi_app = ProfilerMiddleware(app.wsgi_app, profile_dir='/tmp/')
+
+wsgi_app = app.wsgi_app


### PR DESCRIPTION
Changes include:
* Depend on mara-config and mara-cli
* Use functions to compose the app
* Use the mara-config `@set_config()` deorator to compose the app
* Use the new Flask 1.0 way to find the app

This includes the change in #2

It needs newer package version of mara-app (https://github.com/mara/mara-app/pull/23) as the 'flask run' code was moved there.